### PR TITLE
Fix: ESlint and Index import corrections

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
     es6: true,
   },
   plugins: ["@typescript-eslint", "prettier"],
-  ignorePatterns: ["index.ts"],
+  ignorePatterns: [],
   rules: {
     "no-underscore-dangle": 0,
     "no-debugger": 1,

--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Lint
         run: yarn lint
 
-      # - name: Test
-      #   run: yarn test:ci
+      - name: Test
+        run: yarn test:ci
 
   publish:
     name: Build and publish

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-export { default as EditInput } from "./EditInput/EditInput";
-export { default as SelectableTable } from "./SelectableTable/SelectableTable";
-export { default as VirtualizedCarousel } from "./VirtualizedCarousel/VirtualizedCarousel";
-export type { EditInputProps } from "./EditInput/EditInput";
-export type {
+export { default as EditInput, EditInputProps } from "./EditInput/EditInput";
+export {
+  default as SelectableTable,
   SelectableTableButton,
   SelectableTableColumn,
   SelectableTableProps,
   TableDataType
 } from "./SelectableTable/SelectableTable";
-export type { VirtualizedCarouselProps } from "./VirtualizedCarousel/VirtualizedCarousel";
+export {
+  default as VirtualizedCarousel,
+  VirtualizedCarouselProps
+} from "./VirtualizedCarousel/VirtualizedCarousel";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "jsx": "react",
     "outDir": "lib"
   },


### PR DESCRIPTION
- Added index.ts in eslint ignoring files because of a parsing error
when exporting types. This is a known conflict between Typescript and ESlint
https://stackoverflow.com/questions/63331421/export-a-type-after-its-declaration-on-typescript-3-8?noredirect=1&lq=1

- Added corrections to index.ts exports to give easy access to types allong with components
when using the library.