### PR TITLE
fix(form): set value as number for number inputs

### DIFF
--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -260,7 +260,10 @@ const FormSection = <
                 title={property.label}
                 name={property.name}
                 containerStyle={property.containerStyle}
-                inputRef={register(property.validationRules)}
+                inputRef={register({
+                  ...property.validationRules,
+                  valueAsNumber: property.type === "number"
+                })}
                 placeholder={property.placeholder}
                 error={isInputError}
                 variant={property.variant}


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Submitted attributes of type number should be of type number not string.
https://react-hook-form.com/api/useform/register
https://github.com/react-hook-form/react-hook-form/issues/615
https://github.com/react-hook-form/react-hook-form/pull/3489

